### PR TITLE
Add archive notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 
 # pacta.pkgdown.rmitemplate <a href="https://rmi.org"><img src="man/figures/logo.png" align="right" height="31" /></a>
 
+[![Project Status: Unsupported](https://www.repostatus.org/badges/latest/unsupported.svg)](https://www.repostatus.org/#unsupported)
+
+**This project is archived for future reference, but no new work is expected in this repository.**
+
 <!-- badges: start -->
 [![Lifecycle: stable](https://img.shields.io/badge/lifecycle-stable-brightgreen.svg)](https://lifecycle.r-lib.org/articles/stages.html#stable)
 <!-- badges: end -->


### PR DESCRIPTION
This PR marks the repository as archived in the README by adding the unsupported badge and archive notice under the main header.